### PR TITLE
Fix issue with the config page being sized improperly

### DIFF
--- a/src/constants/view_sizes.js
+++ b/src/constants/view_sizes.js
@@ -1,0 +1,13 @@
+export const CONFIG_VIEW_WRAPPER_DIMENSIONS = Object.freeze({
+  overflow: "auto",
+  height: "70vh",
+});
+
+export const CONFIG_VIEW_DIMENSIONS = Object.freeze({
+  width: "100%",
+  height: "700px",
+});
+
+export const PANEL_VIEW_DIMENSIONS = Object.freeze({
+  width: "320px",
+});

--- a/src/extension-view/__snapshots__/component.test.js.snap
+++ b/src/extension-view/__snapshots__/component.test.js.snap
@@ -1,5 +1,432 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<ExtensionView /> when a config type renders correctly 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <ExtensionView
+    deleteViewHandler={[Function]}
+    extension={
+        Object {
+            "authorName": "test",
+            "channelId": "channelId",
+            "description": "description",
+            "iconUrl": "icon_url",
+            "id": "id",
+            "name": "name",
+            "requestIdentity": false,
+            "sku": "sku",
+            "state": "state",
+            "summary": "summary",
+            "token": "token",
+            "vendorCode": "vendorCode",
+            "version": "version",
+            "views": Object {},
+            "whitelistedConfigUrls": "foo",
+            "whitelistedPanelUrls": "bar",
+          }
+    }
+    id="0"
+    linked={false}
+    mode="config"
+    overlaySize={
+        Object {
+            "height": "1px",
+            "width": "1px",
+          }
+    }
+    role="Broadcaster"
+    type="config"
+/>,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <div
+          className="view__header"
+>
+          <div
+                    className="view__descriptor"
+          >
+                    Broadcaster
+          </div>
+          <div
+                    className="view__descriptor"
+          />
+</div>,
+        <div
+          className="view"
+          style={
+                    Object {
+                              "height": "700px",
+                              "width": "100%",
+                            }
+          }
+>
+          <ExtensionFrame
+                    extension={
+                              Object {
+                                        "authorName": "test",
+                                        "channelId": "channelId",
+                                        "description": "description",
+                                        "iconUrl": "icon_url",
+                                        "id": "id",
+                                        "name": "name",
+                                        "requestIdentity": false,
+                                        "sku": "sku",
+                                        "state": "state",
+                                        "summary": "summary",
+                                        "token": "token",
+                                        "vendorCode": "vendorCode",
+                                        "version": "version",
+                                        "views": Object {},
+                                        "whitelistedConfigUrls": "foo",
+                                        "whitelistedPanelUrls": "bar",
+                                      }
+                    }
+                    iframeClassName="rig-frame frameid-0"
+                    mode="config"
+                    type="config"
+          />
+</div>,
+      ],
+      "className": "view__wrapper",
+      "onMouseEnter": [Function],
+      "onMouseLeave": [Function],
+      "style": Object {
+        "height": "70vh",
+        "overflow": "auto",
+      },
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            false,
+            <div
+              className="view__descriptor"
+>
+              Broadcaster
+</div>,
+            <div
+              className="view__descriptor"
+/>,
+          ],
+          "className": "view__header",
+        },
+        "ref": null,
+        "rendered": Array [
+          false,
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": "Broadcaster",
+              "className": "view__descriptor",
+            },
+            "ref": null,
+            "rendered": "Broadcaster",
+            "type": "div",
+          },
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": null,
+              "className": "view__descriptor",
+            },
+            "ref": null,
+            "rendered": null,
+            "type": "div",
+          },
+        ],
+        "type": "div",
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": <ExtensionFrame
+            extension={
+                        Object {
+                                    "authorName": "test",
+                                    "channelId": "channelId",
+                                    "description": "description",
+                                    "iconUrl": "icon_url",
+                                    "id": "id",
+                                    "name": "name",
+                                    "requestIdentity": false,
+                                    "sku": "sku",
+                                    "state": "state",
+                                    "summary": "summary",
+                                    "token": "token",
+                                    "vendorCode": "vendorCode",
+                                    "version": "version",
+                                    "views": Object {},
+                                    "whitelistedConfigUrls": "foo",
+                                    "whitelistedPanelUrls": "bar",
+                                  }
+            }
+            iframeClassName="rig-frame frameid-0"
+            mode="config"
+            type="config"
+/>,
+          "className": "view",
+          "style": Object {
+            "height": "700px",
+            "width": "100%",
+          },
+        },
+        "ref": null,
+        "rendered": Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "extension": Object {
+              "authorName": "test",
+              "channelId": "channelId",
+              "description": "description",
+              "iconUrl": "icon_url",
+              "id": "id",
+              "name": "name",
+              "requestIdentity": false,
+              "sku": "sku",
+              "state": "state",
+              "summary": "summary",
+              "token": "token",
+              "vendorCode": "vendorCode",
+              "version": "version",
+              "views": Object {},
+              "whitelistedConfigUrls": "foo",
+              "whitelistedPanelUrls": "bar",
+            },
+            "iframeClassName": "rig-frame frameid-0",
+            "mode": "config",
+            "type": "config",
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        "type": "div",
+      },
+    ],
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <div
+            className="view__header"
+>
+            <div
+                        className="view__descriptor"
+            >
+                        Broadcaster
+            </div>
+            <div
+                        className="view__descriptor"
+            />
+</div>,
+          <div
+            className="view"
+            style={
+                        Object {
+                                    "height": "700px",
+                                    "width": "100%",
+                                  }
+            }
+>
+            <ExtensionFrame
+                        extension={
+                                    Object {
+                                                "authorName": "test",
+                                                "channelId": "channelId",
+                                                "description": "description",
+                                                "iconUrl": "icon_url",
+                                                "id": "id",
+                                                "name": "name",
+                                                "requestIdentity": false,
+                                                "sku": "sku",
+                                                "state": "state",
+                                                "summary": "summary",
+                                                "token": "token",
+                                                "vendorCode": "vendorCode",
+                                                "version": "version",
+                                                "views": Object {},
+                                                "whitelistedConfigUrls": "foo",
+                                                "whitelistedPanelUrls": "bar",
+                                              }
+                        }
+                        iframeClassName="rig-frame frameid-0"
+                        mode="config"
+                        type="config"
+            />
+</div>,
+        ],
+        "className": "view__wrapper",
+        "onMouseEnter": [Function],
+        "onMouseLeave": [Function],
+        "style": Object {
+          "height": "70vh",
+          "overflow": "auto",
+        },
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              false,
+              <div
+                className="view__descriptor"
+>
+                Broadcaster
+</div>,
+              <div
+                className="view__descriptor"
+/>,
+            ],
+            "className": "view__header",
+          },
+          "ref": null,
+          "rendered": Array [
+            false,
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": "Broadcaster",
+                "className": "view__descriptor",
+              },
+              "ref": null,
+              "rendered": "Broadcaster",
+              "type": "div",
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": null,
+                "className": "view__descriptor",
+              },
+              "ref": null,
+              "rendered": null,
+              "type": "div",
+            },
+          ],
+          "type": "div",
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": <ExtensionFrame
+              extension={
+                            Object {
+                                          "authorName": "test",
+                                          "channelId": "channelId",
+                                          "description": "description",
+                                          "iconUrl": "icon_url",
+                                          "id": "id",
+                                          "name": "name",
+                                          "requestIdentity": false,
+                                          "sku": "sku",
+                                          "state": "state",
+                                          "summary": "summary",
+                                          "token": "token",
+                                          "vendorCode": "vendorCode",
+                                          "version": "version",
+                                          "views": Object {},
+                                          "whitelistedConfigUrls": "foo",
+                                          "whitelistedPanelUrls": "bar",
+                                        }
+              }
+              iframeClassName="rig-frame frameid-0"
+              mode="config"
+              type="config"
+/>,
+            "className": "view",
+            "style": Object {
+              "height": "700px",
+              "width": "100%",
+            },
+          },
+          "ref": null,
+          "rendered": Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "extension": Object {
+                "authorName": "test",
+                "channelId": "channelId",
+                "description": "description",
+                "iconUrl": "icon_url",
+                "id": "id",
+                "name": "name",
+                "requestIdentity": false,
+                "sku": "sku",
+                "state": "state",
+                "summary": "summary",
+                "token": "token",
+                "vendorCode": "vendorCode",
+                "version": "version",
+                "views": Object {},
+                "whitelistedConfigUrls": "foo",
+                "whitelistedPanelUrls": "bar",
+              },
+              "iframeClassName": "rig-frame frameid-0",
+              "mode": "config",
+              "type": "config",
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
+          "type": "div",
+        },
+      ],
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;
+
 exports[`<ExtensionView /> when a panel type renders correctly 1`] = `
 ShallowWrapper {
   "length": 1,
@@ -61,7 +488,6 @@ ShallowWrapper {
           className="view"
           style={
                     Object {
-                              "height": undefined,
                               "width": "320px",
                             }
           }
@@ -96,6 +522,7 @@ ShallowWrapper {
       "className": "view__wrapper",
       "onMouseEnter": [Function],
       "onMouseLeave": [Function],
+      "style": undefined,
     },
     "ref": null,
     "rendered": Array [
@@ -179,7 +606,6 @@ ShallowWrapper {
 />,
           "className": "view",
           "style": Object {
-            "height": undefined,
             "width": "320px",
           },
         },
@@ -243,7 +669,6 @@ ShallowWrapper {
             className="view"
             style={
                         Object {
-                                    "height": undefined,
                                     "width": "320px",
                                   }
             }
@@ -278,6 +703,7 @@ ShallowWrapper {
         "className": "view__wrapper",
         "onMouseEnter": [Function],
         "onMouseLeave": [Function],
+        "style": undefined,
       },
       "ref": null,
       "rendered": Array [
@@ -361,7 +787,6 @@ ShallowWrapper {
 />,
             "className": "view",
             "style": Object {
-              "height": undefined,
               "width": "320px",
             },
           },
@@ -413,7 +838,7 @@ ShallowWrapper {
 }
 `;
 
-exports[`<ExtensionView /> when a panel type renders correctly 2`] = `
+exports[`<ExtensionView /> when a video_overlay type renders correctly 1`] = `
 ShallowWrapper {
   "length": 1,
   Symbol(enzyme.__root__): [Circular],
@@ -515,6 +940,7 @@ ShallowWrapper {
       "className": "view__wrapper",
       "onMouseEnter": [Function],
       "onMouseLeave": [Function],
+      "style": undefined,
     },
     "ref": null,
     "rendered": Array [
@@ -697,6 +1123,7 @@ ShallowWrapper {
         "className": "view__wrapper",
         "onMouseEnter": [Function],
         "onMouseLeave": [Function],
+        "style": undefined,
       },
       "ref": null,
       "rendered": Array [

--- a/src/extension-view/component.js
+++ b/src/extension-view/component.js
@@ -5,7 +5,7 @@ import { ExtensionFrame } from '../extension-frame';
 import { IdentityOptions } from '../constants/identity-options';
 import { ViewerTypes } from '../constants/viewer_types';
 import closeButton from '../img/close_icon.png';
-const { ExtensionAnchor } = window['extension-coordinator'];
+const { ExtensionAnchor, ExtensionMode } = window['extension-coordinator'];
 
 export class ExtensionView extends Component {
   constructor(props) {
@@ -36,11 +36,25 @@ export class ExtensionView extends Component {
     const extensionProps = {}
     switch(this.props.type) {
       case ExtensionAnchor.Panel:
-        extensionProps.width = "320px";
+        extensionProps.viewStyles = {
+          width: "320px",
+        };
         break;
       case ExtensionAnchor.Overlay:
-        extensionProps.width = this.props.overlaySize.width;
-        extensionProps.height = this.props.overlaySize.height;
+        extensionProps.viewStyles = {
+          width: this.props.overlaySize.width,
+          height: this.props.overlaySize.height
+        };
+        break;
+      case ExtensionMode.Config:
+        extensionProps.viewStyles = {
+          width: "100%",
+          height: "700px"
+        };
+        extensionProps.viewWrapperStyles = {
+          overflow: "auto",
+          height: "70vh",
+        };
         break;
       default:
         break;
@@ -51,7 +65,8 @@ export class ExtensionView extends Component {
       <div
         className={'view__wrapper'}
         onMouseEnter={() => { this.mouseEnter() }}
-        onMouseLeave={() => { this.mouseLeave() }}>
+        onMouseLeave={() => { this.mouseLeave() }}
+        style={extensionProps.viewWrapperStyles}>
         <div
           className={'view__header'}>
           {(this.props.deleteViewHandler !== undefined && this.state.mousedOver) &&
@@ -74,10 +89,7 @@ export class ExtensionView extends Component {
         <div
           className="view"
           ref={this._boundIframeHostRefHandler}
-          style={{
-            height: extensionProps.height,
-            width: extensionProps.width,
-          }}>
+          style={extensionProps.viewStyles}>
           <ExtensionFrame
             iframeClassName={`rig-frame frameid-${this.props.id}`}
             extension={this.props.extension}

--- a/src/extension-view/component.js
+++ b/src/extension-view/component.js
@@ -4,6 +4,7 @@ import './component.sass';
 import { ExtensionFrame } from '../extension-frame';
 import { IdentityOptions } from '../constants/identity-options';
 import { ViewerTypes } from '../constants/viewer_types';
+import { CONFIG_VIEW_DIMENSIONS, CONFIG_VIEW_WRAPPER_DIMENSIONS, PANEL_VIEW_DIMENSIONS } from '../constants/view_sizes';
 import closeButton from '../img/close_icon.png';
 const { ExtensionAnchor, ExtensionMode } = window['extension-coordinator'];
 
@@ -36,9 +37,7 @@ export class ExtensionView extends Component {
     const extensionProps = {}
     switch(this.props.type) {
       case ExtensionAnchor.Panel:
-        extensionProps.viewStyles = {
-          width: "320px",
-        };
+        extensionProps.viewStyles = PANEL_VIEW_DIMENSIONS;
         break;
       case ExtensionAnchor.Overlay:
         extensionProps.viewStyles = {
@@ -47,14 +46,8 @@ export class ExtensionView extends Component {
         };
         break;
       case ExtensionMode.Config:
-        extensionProps.viewStyles = {
-          width: "100%",
-          height: "700px"
-        };
-        extensionProps.viewWrapperStyles = {
-          overflow: "auto",
-          height: "70vh",
-        };
+        extensionProps.viewStyles = CONFIG_VIEW_DIMENSIONS;
+        extensionProps.viewWrapperStyles = CONFIG_VIEW_WRAPPER_DIMENSIONS;
         break;
       default:
         break;

--- a/src/extension-view/component.test.js
+++ b/src/extension-view/component.test.js
@@ -45,10 +45,35 @@ describe('<ExtensionView />', () => {
   });
 
 
-  describe('when a panel type', () => {
+  describe('when a video_overlay type', () => {
     const panelType = 'video_overlay';
     const role = 'Broadcaster';
     const mode = 'viewer';
+    const linked = false;
+    const component = shallow(
+      <ExtensionView
+        id={'0'}
+        extension={extension}
+        type={panelType}
+        mode={mode}
+        role={role}
+        linked={linked}
+        overlaySize={{
+          width: '1px',
+          height: '1px',
+        }}
+        deleteViewHandler={() => { }}/>
+    );
+
+    it('renders correctly', () => {
+      expect(component).toMatchSnapshot();
+    });
+  });
+
+  describe('when a config type', () => {
+    const panelType = 'config';
+    const role = 'Broadcaster';
+    const mode = 'config';
     const linked = false;
     const component = shallow(
       <ExtensionView


### PR DESCRIPTION
I had an issue in which the configuration page for my extension for rendering the size of a panel, my extension is a panel extension. Here is what it looked like.
![dev-rig-config-page-issue](https://user-images.githubusercontent.com/1203718/37753825-11f9293a-2d5c-11e8-8f1f-cf195f78c9cc.PNG)

After adding some logic to check if its a config type then we will provide the proper sizing for a configuration page, I got it looking like it does on Twitch.

![dev-rig-config-page-issue-resolved](https://user-images.githubusercontent.com/1203718/37753876-57c3c2e0-2d5c-11e8-97d9-0efb04932ed9.PNG)

Please provide any feedback you guys have if this issue makes sense. I can make any other changes you think are necessary.


**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**