### PR TITLE
Only push to coveralls on latest node version build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,8 @@ script:
   - yarn build
 
 after_success:
-  - coveralls < coverage/lcov.info
+  - test $TRAVIS_NODE_VERSION = "node" &&
+    coveralls < coverage/lcov.info
 
 before_deploy:
   - cd $TRAVIS_BUILD_DIR/build


### PR DESCRIPTION
This will prevent coverage being reported in triplicate