### PR TITLE
Fix clientId which namespaces tokens

### DIFF
--- a/src/rig/component.js
+++ b/src/rig/component.js
@@ -12,7 +12,7 @@ import { ViewerTypes } from '../constants/viewer_types';
 import { OverlaySizes } from '../constants/overlay_sizes';
 import { IdentityOptions } from '../constants/identity-options';
 import { RIG_ROLE } from '../constants/rig';
-const { ExtensionMode } = window['extension-coordinator'];
+const { ExtensionViewType, ExtensionMode } = window['extension-coordinator'];
 
 export class Rig extends Component {
   constructor(props) {
@@ -71,7 +71,7 @@ export class Rig extends Component {
       selectedView: BROADCASTER_CONFIG,
       extension: createExtensionObject(
         this.state.manifest,
-        'config',
+        ExtensionViewType.Config,
         ViewerTypes.Broadcaster,
         '',
         this.state.userName,
@@ -86,7 +86,7 @@ export class Rig extends Component {
       selectedView: LIVE_CONFIG,
       extension: createExtensionObject(
         this.state.manifest,
-        'liveConfig',
+        ExtensionViewType.LiveConfig,
         ViewerTypes.Broadcaster,
         '',
         this.state.userName,

--- a/src/rig/component.js
+++ b/src/rig/component.js
@@ -71,7 +71,7 @@ export class Rig extends Component {
       selectedView: BROADCASTER_CONFIG,
       extension: createExtensionObject(
         this.state.manifest,
-        0,
+        'config',
         ViewerTypes.Broadcaster,
         '',
         this.state.userName,
@@ -86,7 +86,7 @@ export class Rig extends Component {
       selectedView: LIVE_CONFIG,
       extension: createExtensionObject(
         this.state.manifest,
-        0,
+        'liveConfig',
         ViewerTypes.Broadcaster,
         '',
         this.state.userName,

--- a/src/util/extension.js
+++ b/src/util/extension.js
@@ -3,7 +3,7 @@ import { createToken } from './token';
 export function createExtensionObject(manifest, index, role, isLinked, ownerID, channelId, secret) {
   return {
     authorName: manifest.author_name,
-    clientId: manifest.id,
+    clientId: manifest.id + ':' + index,
     description: manifest.description,
     iconUrl: manifest.icon_url,
     id: manifest.id + ':' + index,


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/twitchdev/developer-rig/issues/14

*Description of changes:*
Make sure `clientId` is unique for `Extension Views` as well as `Broadcaster Config` and `Live Config`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
