### PR TITLE
add scripts for generating and installing certs on linux

### DIFF
--- a/scripts/ssl.js
+++ b/scripts/ssl.js
@@ -38,6 +38,8 @@ if (require.main === module) {
     fs.writeFileSync(keyPath, pems.private, { encoding: 'utf-8' });
     if (process.platform === "darwin") {
       shell.exec('./scripts/trust_cert_mac.sh ssl/selfsigned.crt');
+    } else if (process.platform === 'linux') {
+      shell.exec('./scripts/trust_cert_linux.sh ssl/selfsigned.crt');
     } else {
       console.log("Please install the cert into your cert manager found at ssl/selfsigned.crt");
     }

--- a/scripts/trust_cert_linux.sh
+++ b/scripts/trust_cert_linux.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+NAME=${1:-testing}
+
+echo "Installing cert"
+sudo apt-get update
+sudo apt-get install libnss3-tools
+sudo cp ${NAME} /usr/local/share/ca-certificates/
+sudo update-ca-certificates
+certutil -d sql:$HOME/.pki/nssdb -A -t P -n developer-rig -i ${NAME}
+echo "You may need to restart chrome to get the certs to be installed"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
got some feedback to get linux certs working. this should do it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
