### PR TITLE
Config param support

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,13 +130,28 @@ Values for these fields need to be injected as environment variables to the Deve
 * `EXT_CHANNEL`
 * `EXT_OWNER_NAME`
 
+If you don't want to set these values via environment variables, all but the extension secret can be set through a configuration file. This file is specified via a command line argument and is in the format of
+```javascript
+{
+  "clientID": "<client id>",
+  "version": "<version>",
+  "channel": "<channel>",
+  "ownerName": "<owner>"
+}
+```
+
 ### Starting the Developer Rig
 Ensure that the [Developer Rig dependencies](#installing-dependencies) are installed and [required configuration](#developer-rig-configuration) is available.
 
-To start the rig, run:
+To start the rig with environment variables, run:
 ```bash
 EXT_CLIENT_ID=<client id> EXT_SECRET=<secret> EXT_VERSION=<version> EXT_CHANNEL=<channel> EXT_OWNER_NAME=<owner> yarn start
 ```
+To start the rig with a config file and command line arguments, run:
+```bash
+yarn start -s <secret> -c location/of/your/config
+```
+The location of your config file can be either relative to the directory you are running the command or an absolute path to the file.
 
 This will cause your browser to open to `https://localhost.rig.twitch.tv:3000`.
 


### PR DESCRIPTION
*https://github.com/twitchdev/developer-rig/issues/52*

*Description of changes:*
Added support for two CLI arguments. One that specifies the location of a config file and one for specifying the extension secret.

If the secret is set in the CLI argument, then it overrides the environment variable.

If the config file is specified in the CLI argument, then it will read the file and parse the variables form the JSON structure. For each variable defined in the JSON, it will override the environment variable.

Also updated the README so that the usage documentation stays in sync.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
