### PR TITLE
Fixes video component positioning when zoom scaling is on

### DIFF
--- a/src/extension-component-view/__snapshots__/component.test.js.snap
+++ b/src/extension-component-view/__snapshots__/component.test.js.snap
@@ -530,7 +530,11 @@ ShallowWrapper {
       "children": <div
         style={
                 Object {
+                        "border": "1px solid #7D55C7",
                         "height": "0.009765625px",
+                        "left": "20px",
+                        "position": "absolute",
+                        "top": "20px",
                         "transform": "scale(1024)",
                         "transformOrigin": "0 0",
                         "width": "0.009765625px",
@@ -643,7 +647,11 @@ ShallowWrapper {
           type="component"
 />,
         "style": Object {
+          "border": "1px solid #7D55C7",
           "height": "0.009765625px",
+          "left": "20px",
+          "position": "absolute",
+          "top": "20px",
           "transform": "scale(1024)",
           "transformOrigin": "0 0",
           "width": "0.009765625px",
@@ -715,7 +723,11 @@ ShallowWrapper {
         "children": <div
           style={
                     Object {
+                              "border": "1px solid #7D55C7",
                               "height": "0.009765625px",
+                              "left": "20px",
+                              "position": "absolute",
+                              "top": "20px",
                               "transform": "scale(1024)",
                               "transformOrigin": "0 0",
                               "width": "0.009765625px",
@@ -828,7 +840,11 @@ ShallowWrapper {
             type="component"
 />,
           "style": Object {
+            "border": "1px solid #7D55C7",
             "height": "0.009765625px",
+            "left": "20px",
+            "position": "absolute",
+            "top": "20px",
             "transform": "scale(1024)",
             "transformOrigin": "0 0",
             "width": "0.009765625px",

--- a/src/extension-component-view/component.js
+++ b/src/extension-component-view/component.js
@@ -29,6 +29,7 @@ export class ExtensionComponentView extends Component {
 
     if (extension.views.component.zoom) {
       viewStyles = {
+        ...viewStyles,
         width: `${sizeFromView.width / sizeFromView.zoomScale}px`,
         height: `${sizeFromView.height / sizeFromView.zoomScale}px`,
         transformOrigin: '0 0',

--- a/src/extension-view/component.sass
+++ b/src/extension-view/component.sass
@@ -6,6 +6,7 @@
 
 .component-view
   background-color: #322F37
+  overflow: hidden
 
 .view__wrapper
   padding: 2em


### PR DESCRIPTION
*Issue #, if available:* #62 & #64 

*Description of changes:*
Following @BarryCarlyon 's discovery in #64 that the issue only happens when he has zoom scaling on, I've noticed that when zoom feature is on, the component view overwrites the value of `viewStyles`. This PR makes sure to expand the existing values of `viewStyles` into the new object to keep the positioning data instead of overwriting it.

In addition, I've added `overflow: hidden` to the `.component-view` to prevent components positioned out of bounds to cause issues with the page layout.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
