### PR TITLE
Fix  live config panel height

### DIFF
--- a/src/constants/view_sizes.js
+++ b/src/constants/view_sizes.js
@@ -9,6 +9,6 @@ export const CONFIG_VIEW_DIMENSIONS = Object.freeze({
 });
 
 export const PANEL_VIEW_DIMENSIONS = Object.freeze({
-  width: "320px",
-  height: "150px",
+  width: "320",
+  height: "300",
 });

--- a/src/extension-view/__snapshots__/component.test.js.snap
+++ b/src/extension-view/__snapshots__/component.test.js.snap
@@ -1144,8 +1144,8 @@ ShallowWrapper {
           className="view"
           style={
                     Object {
-                              "height": "150pxpx",
-                              "width": "320pxpx",
+                              "height": "300px",
+                              "width": "320px",
                             }
           }
 >
@@ -1305,8 +1305,8 @@ ShallowWrapper {
 />,
           "className": "view",
           "style": Object {
-            "height": "150pxpx",
-            "width": "320pxpx",
+            "height": "300px",
+            "width": "320px",
           },
         },
         "ref": null,
@@ -1390,8 +1390,8 @@ ShallowWrapper {
             className="view"
             style={
                         Object {
-                                    "height": "150pxpx",
-                                    "width": "320pxpx",
+                                    "height": "300px",
+                                    "width": "320px",
                                   }
             }
 >
@@ -1551,8 +1551,8 @@ ShallowWrapper {
 />,
             "className": "view",
             "style": Object {
-              "height": "150pxpx",
-              "width": "320pxpx",
+              "height": "300px",
+              "width": "320px",
             },
           },
           "ref": null,
@@ -2769,8 +2769,8 @@ ShallowWrapper {
           className="view"
           style={
                     Object {
-                              "height": "150pxpx",
-                              "width": "320pxpx",
+                              "height": "300px",
+                              "width": "320px",
                             }
           }
 >
@@ -2932,8 +2932,8 @@ ShallowWrapper {
 />,
           "className": "view",
           "style": Object {
-            "height": "150pxpx",
-            "width": "320pxpx",
+            "height": "300px",
+            "width": "320px",
           },
         },
         "ref": null,
@@ -3019,8 +3019,8 @@ ShallowWrapper {
             className="view"
             style={
                         Object {
-                                    "height": "150pxpx",
-                                    "width": "320pxpx",
+                                    "height": "300px",
+                                    "width": "320px",
                                   }
             }
 >
@@ -3182,8 +3182,8 @@ ShallowWrapper {
 />,
             "className": "view",
             "style": Object {
-              "height": "150pxpx",
-              "width": "320pxpx",
+              "height": "300px",
+              "width": "320px",
             },
           },
           "ref": null,
@@ -3351,8 +3351,8 @@ ShallowWrapper {
           className="view"
           style={
                     Object {
-                              "height": "150pxpx",
-                              "width": "320pxpx",
+                              "height": "300px",
+                              "width": "320px",
                             }
           }
 >
@@ -3514,8 +3514,8 @@ ShallowWrapper {
 />,
           "className": "view",
           "style": Object {
-            "height": "150pxpx",
-            "width": "320pxpx",
+            "height": "300px",
+            "width": "320px",
           },
         },
         "ref": null,
@@ -3601,8 +3601,8 @@ ShallowWrapper {
             className="view"
             style={
                         Object {
-                                    "height": "150pxpx",
-                                    "width": "320pxpx",
+                                    "height": "300px",
+                                    "width": "320px",
                                   }
             }
 >
@@ -3764,8 +3764,8 @@ ShallowWrapper {
 />,
             "className": "view",
             "style": Object {
-              "height": "150pxpx",
-              "width": "320pxpx",
+              "height": "300px",
+              "width": "320px",
             },
           },
           "ref": null,
@@ -3931,8 +3931,8 @@ ShallowWrapper {
           className="view"
           style={
                     Object {
-                              "height": "150pxpx",
-                              "width": "320pxpx",
+                              "height": "300px",
+                              "width": "320px",
                             }
           }
 >
@@ -4092,8 +4092,8 @@ ShallowWrapper {
 />,
           "className": "view",
           "style": Object {
-            "height": "150pxpx",
-            "width": "320pxpx",
+            "height": "300px",
+            "width": "320px",
           },
         },
         "ref": null,
@@ -4177,8 +4177,8 @@ ShallowWrapper {
             className="view"
             style={
                         Object {
-                                    "height": "150pxpx",
-                                    "width": "320pxpx",
+                                    "height": "300px",
+                                    "width": "320px",
                                   }
             }
 >
@@ -4338,8 +4338,8 @@ ShallowWrapper {
 />,
             "className": "view",
             "style": Object {
-              "height": "150pxpx",
-              "width": "320pxpx",
+              "height": "300px",
+              "width": "320px",
             },
           },
           "ref": null,
@@ -4505,8 +4505,8 @@ ShallowWrapper {
           className="view"
           style={
                     Object {
-                              "height": "150pxpx",
-                              "width": "320pxpx",
+                              "height": "300px",
+                              "width": "320px",
                             }
           }
 >
@@ -4666,8 +4666,8 @@ ShallowWrapper {
 />,
           "className": "view",
           "style": Object {
-            "height": "150pxpx",
-            "width": "320pxpx",
+            "height": "300px",
+            "width": "320px",
           },
         },
         "ref": null,
@@ -4751,8 +4751,8 @@ ShallowWrapper {
             className="view"
             style={
                         Object {
-                                    "height": "150pxpx",
-                                    "width": "320pxpx",
+                                    "height": "300px",
+                                    "width": "320px",
                                   }
             }
 >
@@ -4912,8 +4912,8 @@ ShallowWrapper {
 />,
             "className": "view",
             "style": Object {
-              "height": "150pxpx",
-              "width": "320pxpx",
+              "height": "300px",
+              "width": "320px",
             },
           },
           "ref": null,
@@ -5081,8 +5081,8 @@ ShallowWrapper {
           className="view"
           style={
                     Object {
-                              "height": "150pxpx",
-                              "width": "320pxpx",
+                              "height": "300px",
+                              "width": "320px",
                             }
           }
 >
@@ -5244,8 +5244,8 @@ ShallowWrapper {
 />,
           "className": "view",
           "style": Object {
-            "height": "150pxpx",
-            "width": "320pxpx",
+            "height": "300px",
+            "width": "320px",
           },
         },
         "ref": null,
@@ -5331,8 +5331,8 @@ ShallowWrapper {
             className="view"
             style={
                         Object {
-                                    "height": "150pxpx",
-                                    "width": "320pxpx",
+                                    "height": "300px",
+                                    "width": "320px",
                                   }
             }
 >
@@ -5494,8 +5494,8 @@ ShallowWrapper {
 />,
             "className": "view",
             "style": Object {
-              "height": "150pxpx",
-              "width": "320pxpx",
+              "height": "300px",
+              "width": "320px",
             },
           },
           "ref": null,
@@ -5663,8 +5663,8 @@ ShallowWrapper {
           className="view"
           style={
                     Object {
-                              "height": "150pxpx",
-                              "width": "320pxpx",
+                              "height": "300px",
+                              "width": "320px",
                             }
           }
 >
@@ -5826,8 +5826,8 @@ ShallowWrapper {
 />,
           "className": "view",
           "style": Object {
-            "height": "150pxpx",
-            "width": "320pxpx",
+            "height": "300px",
+            "width": "320px",
           },
         },
         "ref": null,
@@ -5913,8 +5913,8 @@ ShallowWrapper {
             className="view"
             style={
                         Object {
-                                    "height": "150pxpx",
-                                    "width": "320pxpx",
+                                    "height": "300px",
+                                    "width": "320px",
                                   }
             }
 >
@@ -6076,8 +6076,8 @@ ShallowWrapper {
 />,
             "className": "view",
             "style": Object {
-              "height": "150pxpx",
-              "width": "320pxpx",
+              "height": "300px",
+              "width": "320px",
             },
           },
           "ref": null,
@@ -6243,8 +6243,8 @@ ShallowWrapper {
           className="view"
           style={
                     Object {
-                              "height": "150pxpx",
-                              "width": "320pxpx",
+                              "height": "300px",
+                              "width": "320px",
                             }
           }
 >
@@ -6404,8 +6404,8 @@ ShallowWrapper {
 />,
           "className": "view",
           "style": Object {
-            "height": "150pxpx",
-            "width": "320pxpx",
+            "height": "300px",
+            "width": "320px",
           },
         },
         "ref": null,
@@ -6489,8 +6489,8 @@ ShallowWrapper {
             className="view"
             style={
                         Object {
-                                    "height": "150pxpx",
-                                    "width": "320pxpx",
+                                    "height": "300px",
+                                    "width": "320px",
                                   }
             }
 >
@@ -6650,8 +6650,8 @@ ShallowWrapper {
 />,
             "className": "view",
             "style": Object {
-              "height": "150pxpx",
-              "width": "320pxpx",
+              "height": "300px",
+              "width": "320px",
             },
           },
           "ref": null,
@@ -6813,7 +6813,7 @@ ShallowWrapper {
           style={
                     Object {
                               "height": "300pxpx",
-                              "width": "320pxpx",
+                              "width": "320px",
                             }
           }
 >
@@ -6964,7 +6964,7 @@ ShallowWrapper {
           "className": "view",
           "style": Object {
             "height": "300pxpx",
-            "width": "320pxpx",
+            "width": "320px",
           },
         },
         "ref": null,
@@ -7044,7 +7044,7 @@ ShallowWrapper {
             style={
                         Object {
                                     "height": "300pxpx",
-                                    "width": "320pxpx",
+                                    "width": "320px",
                                   }
             }
 >
@@ -7195,7 +7195,7 @@ ShallowWrapper {
             "className": "view",
             "style": Object {
               "height": "300pxpx",
-              "width": "320pxpx",
+              "width": "320px",
             },
           },
           "ref": null,
@@ -7356,7 +7356,7 @@ ShallowWrapper {
           className="view"
           style={
                     Object {
-                              "height": "150px",
+                              "height": "300px",
                               "width": "320px",
                             }
           }
@@ -7517,7 +7517,7 @@ ShallowWrapper {
 />,
           "className": "view",
           "style": Object {
-            "height": "150px",
+            "height": "300px",
             "width": "320px",
           },
         },
@@ -7602,7 +7602,7 @@ ShallowWrapper {
             className="view"
             style={
                         Object {
-                                    "height": "150px",
+                                    "height": "300px",
                                     "width": "320px",
                                   }
             }
@@ -7763,7 +7763,7 @@ ShallowWrapper {
 />,
             "className": "view",
             "style": Object {
-              "height": "150px",
+              "height": "300px",
               "width": "320px",
             },
           },

--- a/src/extension-view/component.js
+++ b/src/extension-view/component.js
@@ -112,7 +112,10 @@ export class ExtensionView extends Component {
         }
         break;
       default:
-        extensionProps.viewStyles = PANEL_VIEW_DIMENSIONS;
+        extensionProps.viewStyles = {
+          height: PANEL_VIEW_DIMENSIONS.height + 'px',
+          width: PANEL_VIEW_DIMENSIONS.width + 'px',
+        }
         break;
     }
 


### PR DESCRIPTION
*Issue #, if available:* fixes #69 

*Description of changes:*
- Updates the panel size constants height to match the documented 300px as the default value.
- Removes the `px` units (this was causing some styles to have values ending in `pxpx` which was not valid css) from the constants to match the values that dev rig gets from the extension manifest. Updates the view style logic to reflect this and injects the `px` units in the logic.
- Updates the jest snapshots to reflect changes in generated style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
