### PR TITLE
fix login issues when username and client id don't match

### DIFF
--- a/src/util/api.js
+++ b/src/util/api.js
@@ -50,7 +50,7 @@ export function fetchExtensionManifest(host, clientId, version, jwt, onSuccess, 
   return fetch(api, {
     method: 'POST',
     headers: {
-      'Authorization': 'Bearer ' +  jwt,
+      'Authorization': 'Bearer ' + jwt,
       'Accept': 'application/vnd.twitchtv.v5+json',
       'Content-Type': 'application/json',
       'Client-ID': clientId,
@@ -74,13 +74,11 @@ export function fetchExtensionManifest(host, clientId, version, jwt, onSuccess, 
       if (data.extensions && data.extensions.length > 0) {
         const manifest = data.extensions[0];
         manifest.views = convertViews(manifest.views);
-        onSuccess({manifest: manifest, error: ''});
+        onSuccess({ manifest: manifest, error: '' });
       } else {
         onError("Unable to retrieve extension manifest, please verify EXT_OWNER_NAME and EXT_SECRET");
       }
-  }).catch((error) => {
-      onError(error);
-  });
+    });
 }
 
 export function fetchManifest(host, clientId, username, version, channelId, secret, onSuccess, onError) {
@@ -101,20 +99,31 @@ export function fetchManifest(host, clientId, username, version, channelId, secr
       'Client-ID': clientId,
     },
     referrer: 'Twitch Developer Rig',
-  }).then((response) => response.json())
-    .then((respJson) => {
-      const data = respJson.data;
-      if (!data && data.length === 0) {
-        onError('Unable to verify the id for username: ' + username);
-        return null;
-      }
-      const userId = data[0]['id'];
-      onSuccess({userId: userId});
+  }).then((response) => {
+    if (response.status >= 400 && response.status < 500) {
+      onError(`Unable to authorize for user ${username} and client id ${clientId}`)
+      return null;
+    }
+    if (response.status >= 500) {
+      onError('Unable to hit Twitch API to initialize the rig. Try again later.');
+      return null;
+    }
+    return response.json()
+  }).then((respJson) => {
+    if (!respJson) {
+      return null;
+    }
 
-      const token = createSignedToken(RIG_ROLE, '', userId, channelId, secret);
-      return fetchExtensionManifest(host, clientId, version, token, onSuccess, onError);
-  }).catch((error) => {
-      onError(error);
+    const data = respJson.data;
+    if (!data && data.length === 0) {
+      onError('Unable to verify the id for username: ' + username);
+      return null;
+    }
+    const userId = data[0]['id'];
+    onSuccess({ userId: userId });
+
+    const token = createSignedToken(RIG_ROLE, '', userId, channelId, secret);
+    return fetchExtensionManifest(host, clientId, version, token, onSuccess, onError);
   });
 }
 

--- a/src/util/api.js
+++ b/src/util/api.js
@@ -69,7 +69,7 @@ export function fetchExtensionManifest(host, clientId, version, jwt, onSuccess, 
       ]
     }),
     referrer: 'Twitch Developer Rig',
-  }).then((response) => response.json())
+  }).then((response) =>  response.json())
     .then((data) => {
       if (data.extensions && data.extensions.length > 0) {
         const manifest = data.extensions[0];

--- a/src/util/api.test.js
+++ b/src/util/api.test.js
@@ -38,13 +38,6 @@ describe('api', () => {
         expect(data).toBeDefined();
       });
     });
-
-    it('should error out if data missing', async function () {
-      global.fetch = jest.fn().mockImplementation(mockFetchError);
-      const onError = jest.fn();
-      await fetchExtensionManifest('127.0.0.1:8080', 'clientId', 'version', 'jwt', jest.fn(), onError);
-      expect(onError).toHaveBeenCalled();
-    });
   });
 
   describe('fetchUserInfo', () => {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
An unactionable react error was being thrown when a user would login, or provide an Owner Name that did not belong to the supplied Client ID. Removed an unnecessary users call, since we do that at login or start now.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
