### PR TITLE
re-add trust_cert_mac script; fixes twitch-dev/developer-rig#117

### DIFF
--- a/scripts/ssl.js
+++ b/scripts/ssl.js
@@ -37,7 +37,7 @@ if (require.main === module) {
     fs.writeFileSync(certPath, pems.cert, { encoding: 'utf-8' });
     fs.writeFileSync(keyPath, pems.private, { encoding: 'utf-8' });
     if (process.platform === "darwin") {
-      shell.exec('./scripts/trust_cert_mac.sh ssl/selfsigned.crt');
+      shell.exec('sh ./scripts/trust_cert_mac.sh ssl/selfsigned.crt');
     } else {
       console.log("Please install the cert into your cert manager found at ssl/selfsigned.crt");
     }

--- a/scripts/trust_cert_mac.sh
+++ b/scripts/trust_cert_mac.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+CERT_NAME=${1:-selfsigned}
+CERT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"; cd ../ && pwd )"
+ echo "Installing cert into local Keychain."
+echo "To see or modify, run 'Keychain Access' app and look in the 'System' Folder"
+
+sudo security add-trusted-cert -d -p ssl -r trustRoot -k "/Library/Keychains/System.keychain" "${CERT_DIR}/${CERT_NAME}"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7510,7 +7510,7 @@ react-reconciler@^0.7.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react-redux@^5.0.7:
+react-redux@5.0.7:
   version "5.0.7"
   resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-5.0.7.tgz#0dc1076d9afb4670f993ffaef44b8f8c1155a4c8"
   dependencies:


### PR DESCRIPTION
*Issue #, if available:*

fixes #117 

*Description of changes:*

Re-added the `scripts_trust_cert_mac.sh` file and updated `CERT_DIR` and `CERT_NAME` variables so it looks for the cert in the correct location. Finally, I changed the way the script is executed so it doesn't have to be `chmod`-ed to work.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
