### PR TITLE
Fix nono_zones being 4px too tall

### DIFF
--- a/src/extension-view/component.sass
+++ b/src/extension-view/component.sass
@@ -9,24 +9,26 @@
   z-index: 1;
   top: 0;
   left: 0;
-  width: 99.5%;
+  width: 100%;
   height: 100px;
   content: "";
   opacity: 0.6;
   background-color: #6441a4;
   border: 2px solid #b19dd8;
+  box-sizing: border-box;
 
 .nono_zone:after
   position: absolute;
   z-index: 1;
   bottom: 0;
   right: 0;
-  width: 99.5%;
+  width: 100%;
   height: 80px;
   content: "";
   opacity: 0.6;
   background-color: #6441a4;
   border: 2px solid #b19dd8;
+  box-sizing: border-box;
 
 .component-view
   background-color: #322F37


### PR DESCRIPTION
*Issue #, if available:*
The `nono_zone` overlays are 4px too tall.

*Description of changes:*
Apply `box-sizing: border-box` to the `nono_zone` overlays so they are exactly 100px and 80px as specified by their height. This also let's us set them to `width: 100%` instead of `width: 99.5%` so they are flush with the edge of the viewport at any resolution.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
