### PR TITLE
Fixing the Organization Name in the SSL configuration

### DIFF
--- a/scripts/openssl-server.cnf
+++ b/scripts/openssl-server.cnf
@@ -23,7 +23,7 @@ localityName                   = Locality Name (eg, city)
 localityName_default           = San Francisco
 
 organizationName               = Organization Name (eg, company)
-organizationName_default       = Twtich
+organizationName_default       = Twitch
 
 organizationalUnitName         = Organizational Unit (eg, division)
 organizationalUnitName_default = Twitch Developer Rig


### PR DESCRIPTION
I just noticed this some minutes ago, and I've already posted the issue in the Developer Server. I'm just making it somewhat formal here.
Apparently there's a typo in the Organization Name in the SSL config file 😅

![image](https://user-images.githubusercontent.com/20666039/45849308-4e506300-bd29-11e8-99ff-f4ffa72b9a5e.png)
