### PR TITLE
Fixed crash in Add a new view - Mobile

### DIFF
--- a/src/extension-view-dialog/component.tsx
+++ b/src/extension-view-dialog/component.tsx
@@ -8,7 +8,7 @@ import { ViewTypeImages } from '../constants/img-map';
 import { RadioOption } from './radio-option';
 import { DivOption } from './div-option';
 import * as closeButton from '../img/close_icon.png';
-import { MobileOrientation, DefaultMobileOrientation, MobileSizes } from '../constants/mobile';
+import { MobileOrientation, DefaultMobileOrientation, MobileSizes, DefaultMobileSize } from '../constants/mobile';
 import { getSupportedAnchors, getSupportedPlatforms } from '../core/models/manifest';
 import { ExtensionAnchor, ExtensionMode, ExtensionPlatform, ExtensionViewType } from '../constants/extension-coordinator';
 
@@ -23,6 +23,7 @@ export interface ExtensionViewDialogState {
   extensionViewType: ExtensionAnchor | ExtensionMode | ExtensionPlatform | ExtensionViewType;
   channelId: string;
   frameSize: string;
+  mobileFrameSize: string;
   isChatEnabled: boolean;
   isPopout: boolean;
   viewerType: string;
@@ -44,6 +45,7 @@ export class ExtensionViewDialog extends React.Component<ExtensionViewDialogProp
     isChatEnabled: false,
     isPopout: false,
     frameSize: DefaultOverlaySize,
+    mobileFrameSize: DefaultMobileSize,
     viewerType: DefaultViewerType,
     x: 0,
     y: 0,
@@ -115,7 +117,7 @@ export class ExtensionViewDialog extends React.Component<ExtensionViewDialogProp
 
   private renderMobileFrameSizeComponents() {
     return Object.keys(MobileSizes).map(key => {
-      return <RadioOption key={key} name="frameSize" value={key} onChange={this.onChange} checked={key === this.state.frameSize} />
+      return <RadioOption key={key} name="mobileFrameSize" value={key} onChange={this.onChange} checked={key === this.state.mobileFrameSize} />
     });
   }
 
@@ -224,7 +226,7 @@ export class ExtensionViewDialog extends React.Component<ExtensionViewDialogProp
                           {this.renderMobileFrameSizeComponents()}
                         </div>
                         <div className='overlay-custom-container'>
-                          <RadioOption className='overlay-custom' name="frameSize" value="Custom" onChange={this.onChange} checked={"Custom" === DefaultIdentityOption} />
+                          <RadioOption className='overlay-custom' name="mobileFrameSize" value="Custom" onChange={this.onChange} checked={"Custom" === DefaultIdentityOption} />
                           <div className='overlay-custom-container'>
                             <div className="custom-subcontainer__input">
                               <label className="inputs__option-label inputs__width-offset"> Width </label>

--- a/src/rig/component.test.tsx
+++ b/src/rig/component.test.tsx
@@ -204,7 +204,7 @@ describe('<RigComponent />', () => {
     const testDialogState = {
       width: 0,
       height: 0,
-      frameSize: 'iPhone X (375x822)',
+      mobileFrameSize: 'iPhone X (375x822)',
       extensionViewType: ExtensionViewType.Mobile
     } as ExtensionViewDialogState;
     const expectedMobileFrameSize = {

--- a/src/rig/component.tsx
+++ b/src/rig/component.tsx
@@ -101,17 +101,16 @@ export class RigComponent extends React.Component<Props, State> {
   }
 
   public getFrameSizeFromDialog(extensionViewDialogState: ExtensionViewDialogState) {
-    if (extensionViewDialogState.frameSize === 'Custom') {
+    const key = extensionViewDialogState.extensionViewType === ExtensionViewType.Mobile ? 'mobileFrameSize' : 'frameSize';
+    if (extensionViewDialogState[key] === 'Custom') {
       return {
         width: extensionViewDialogState.width,
         height: extensionViewDialogState.height
       };
     }
-    if (extensionViewDialogState.extensionViewType === ExtensionViewType.Mobile) {
-      return MobileSizes[extensionViewDialogState.frameSize];
-    }
 
-    return OverlaySizes[extensionViewDialogState.frameSize];
+    const sizes = extensionViewDialogState.extensionViewType === ExtensionViewType.Mobile ? MobileSizes : OverlaySizes;''
+    return sizes[extensionViewDialogState[key]];
   }
 
   public createExtensionView = async (extensionViewDialogState: ExtensionViewDialogState) => {


### PR DESCRIPTION
*Issue #, if available:* #201

*Description of changes:*
Added a new state variable to ExtensionViewDialogState - mobileFrameSize.
Mirrors frameSize but is used exclusively for the Mobile options view.
This is to have a sane default variable when the dialog is opened.
Now you can not accidentaly click Save without an option selected, corrupting your rig state.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
